### PR TITLE
Updated to include more comics

### DIFF
--- a/lib/cogs/xkcd.py
+++ b/lib/cogs/xkcd.py
@@ -14,7 +14,7 @@ class Xkcd(Cog):
 		'''Gives the current xkcd comic'''
 		t = datetime.datetime.utcnow()
 
-		random_number = random.randint(1, 1000)
+		random_number = random.randint(1, 2386)
 		#await ctx.send(random_number)
 
 		xkcd_url = f"https://xkcd.com/{random_number}/info.0.json"


### PR DESCRIPTION
Temporary manual solution for making the bot show other half of the comics.
A more permanent solution would be query through the api for the latest comic (`https://xkcd.com/info.0.json` gives the `num` value). 
Would implement it if I get some time.